### PR TITLE
Add fax support

### DIFF
--- a/lib/signalwire/sdk.rb
+++ b/lib/signalwire/sdk.rb
@@ -6,6 +6,7 @@ require 'signalwire/sdk/configuration'
 require 'signalwire/sdk/twilio_set_host'
 require 'signalwire/sdk/domain'
 require 'signalwire/sdk/voice_response'
+require 'signalwire/sdk/fax_response'
 require 'signalwire/sdk/messaging_response'
 require 'signalwire/rest/client'
 

--- a/lib/signalwire/sdk/fax_response.rb
+++ b/lib/signalwire/sdk/fax_response.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'twilio-ruby/twiml/fax_response'
+
+module Signalwire::Sdk
+  class FaxResponse < Twilio::TwiML::FaxResponse
+    # Create a new <Reject> element
+    # keyword_args:: additional attributes
+    def reject(reason: nil, **keyword_args)
+      append(Reject.new(**keyword_args))
+    end
+    
+    # <Leave> TwiML Verb
+    class Reject < ::Twilio::TwiML::TwiML
+      def initialize(**keyword_args)
+        super(**keyword_args)
+        @name = 'Reject'
+
+        yield(self) if block_given?
+      end
+    end
+  end
+end
+

--- a/spec/signalwire/sdk/fax_response_spec.rb
+++ b/spec/signalwire/sdk/fax_response_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Signalwire
+  RSpec.describe Sdk::FaxResponse do
+    it 'generates the correct LAML' do
+      response = Signalwire::Sdk::FaxResponse.new do |r|
+        r.receive(action: '/receive/fax')
+      end
+
+      expect(response.to_s).to eq "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n"\
+        "<Receive action=\"/receive/fax\"/>\n</Response>\n"
+    end
+
+    it 'can reject a fax' do
+      response = Signalwire::Sdk::FaxResponse.new do |r|
+        r.reject
+      end
+
+      expect(response.to_s).to eq "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response>\n"\
+        "<Reject/>\n</Response>\n"
+    end
+  end
+end
+


### PR DESCRIPTION
Includes the `Reject` verb that Twilio does not have in their own API.