### PR TITLE
Blade error handling

### DIFF
--- a/lib/signalwire/blade/message.rb
+++ b/lib/signalwire/blade/message.rb
@@ -34,5 +34,17 @@ module Signalwire::Blade
     def to_s
       inspect
     end
+
+    def error?
+      @payload.has_key?(:error)
+    end
+
+    def error_code
+      @payload.dig(:error, :code)
+    end
+
+    def error_message
+      @payload.dig(:error, :message)
+    end
   end
 end

--- a/lib/signalwire/relay/client.rb
+++ b/lib/signalwire/relay/client.rb
@@ -121,7 +121,11 @@ module Signalwire::Relay
       @session.on :connected do |event|
         logger.debug 'Relay client connected'
         broadcast :connecting, event
-        protocol_setup
+        if event.error?
+          logger.error("Error setting up Blade connection")
+        else
+          protocol_setup
+        end
       end
     end
 
@@ -137,19 +141,23 @@ module Signalwire::Relay
       setup[:params][:protocol] = @protocol if @protocol
 
       @session.execute(setup) do |event|
-        @protocol = event.dig(:result, :result, :protocol)
-        logger.debug "Protocol set up as #{protocol}"
+        if event.error?
+          logger.error("Error setting up Relay protocol")
+        else
+          @protocol = event.dig(:result, :result, :protocol)
+          logger.debug "Protocol set up as #{protocol}"
 
-        notification_request = {
-          "protocol": @protocol,
-          "command": 'add',
-          "channels": ['notifications']
-        }
+          notification_request = {
+            "protocol": @protocol,
+            "command": 'add',
+            "channels": ['notifications']
+          }
 
-        @session.subscribe(notification_request) do
-          logger.debug "Subscribed to notifications for #{protocol}"
-          @connected = true
-          broadcast :ready, self
+          @session.subscribe(notification_request) do
+            logger.debug "Subscribed to notifications for #{protocol}"
+            @connected = true
+            broadcast :ready, self
+          end
         end
       end
     end

--- a/lib/signalwire/relay/client.rb
+++ b/lib/signalwire/relay/client.rb
@@ -79,7 +79,7 @@ module Signalwire::Relay
           block.call(event, success) if block_given?
           logger.error "Relay command failed with code #{code} and message: #{message}" unless success
         else
-          logger.error 'Unknown Relay command failure, result code not found'
+          logger.error("Relay error occurred, code #{event.error_code}: #{event.error_message}") if event.error?
           block.call(event, :failure) if block_given?
         end
       else

--- a/spec/signalwire/blade/message_spec.rb
+++ b/spec/signalwire/blade/message_spec.rb
@@ -32,4 +32,21 @@ describe Signalwire::Blade::Message do
       expect(msg[:someval]).to eq 'foo'
     end
   end
+
+  describe 'error?' do
+    let(:error_hash) do
+      { error: { code: '-9999', message: 'Something went horribly wrong' } }
+    end
+
+    it "returns true if error" do
+      obj = described_class.new(error_hash)
+      expect(obj.error?).to eq true
+      expect(obj.error_code).to eq error_hash[:error][:code]
+      expect(obj.error_message).to eq error_hash[:error][:message]
+    end
+
+    it "returns false if not an error" do
+      expect(subject.error?).to eq false
+    end
+  end
 end

--- a/spec/signalwire/relay/client_spec.rb
+++ b/spec/signalwire/relay/client_spec.rb
@@ -36,6 +36,20 @@ describe Signalwire::Relay::Client do
     end
   end
 
+  describe '#setup_handlers' do
+    let(:error_event) { Signalwire::Blade::Message.new({ error: { code: '-9999', message: 'Something went horribly wrong' } }) }
+    let(:result_event) { Signalwire::Blade::Message.new({ result: { code: '200', message: 'All good' } }) }
+    it "does not setup protocol on a failed login" do
+      expect(subject).to receive(:protocol_setup).never
+      subject.session.broadcast(:connected, error_event)
+    end
+
+    it "does setup protocol on a successful login" do
+      expect(subject).to receive(:protocol_setup).once
+      subject.session.broadcast(:connected, result_event)
+    end
+  end
+
   describe '#relay_execute' do
     let(:receive_message) { {
       "protocol": 'myprotocol',


### PR DESCRIPTION
Resolution for #41 . Needs reviewing. @bryanrite , in your opinion would it be ok to let promises time out on an error? That way I could move the error handling one level up. Otherwise, it needs to be handled case-by-case as in this initial implementation. This does already stop the client from progressing if the Relay setup fails.