### PR TITLE
Fix result values on handling amd

### DIFF
--- a/lib/signalwire/relay/calling/component/detect.rb
+++ b/lib/signalwire/relay/calling/component/detect.rb
@@ -44,7 +44,7 @@ module Signalwire::Relay::Calling
       return complete(event) if FINISHED_EVENTS.include?(@state) || @type == Relay::CallDetectType::DIGIT
 
       if has_blocker?
-        @received_events << @state 
+        @received_events << @state
         return
       end
 
@@ -56,7 +56,7 @@ module Signalwire::Relay::Calling
         @waiting_for_ready = true
         return
       end
-      
+
       check_for_waiting_events
       broadcast_event(event)
     end
@@ -71,9 +71,9 @@ module Signalwire::Relay::Calling
     def complete(event)
       @completed = true
       @event = event
-      
+
       if has_blocker?
-        @successful = !FINISHED_EVENTS.include?(@state)
+        @successful = @state == Relay::CallDetectState::FINISHED
 
         if MACHINE_EVENTS.include?(@state)
           @result = Relay::CallDetectState::MACHINE

--- a/spec/signalwire/relay/calling/component/detect_spec.rb
+++ b/spec/signalwire/relay/calling/component/detect_spec.rb
@@ -7,64 +7,116 @@ describe Signalwire::Relay::Calling::Detect do
     {
       "type": "machine",
       "params": {
-         "initial_timeout": 5.0
+        "initial_timeout": 5.0
       }
     }
   end
+
   let(:wait_for_beep) { false }
   subject { described_class.new(call: call, detect: detect, wait_for_beep: wait_for_beep) }
 
-  describe "#execute_params" do
-    it "has the correct payload" do
-      expect(subject.execute_params).to eq({
-        method: subject.method,
-        protocol: client.protocol,
-        params: {
-          call_id: call.id, 
-          control_id: subject.control_id,
-          detect: detect, 
-          node_id:call.node_id, 
-          timeout: 30
-        }
-      })
-    end
-  end
+  context "No wait for beep" do
 
-  describe "#notification_handler" do
-    let(:mock_detect_event) do
-      Signalwire::Relay::Event.new({
-        params: { params: { params: {
-          detect: {
-            type: event_type,
-            params: {
-              event: event_value
-            }
+    describe "#execute_params" do
+      it "has the correct payload" do
+        expect(subject.execute_params).to eq({
+          method: subject.method,
+          protocol: client.protocol,
+          params: {
+            call_id: call.id,
+            control_id: subject.control_id,
+            detect: detect,
+            node_id:call.node_id,
+            timeout: 30
           }
-        }}}
-      })
-    end
-
-    describe "digits" do
-      let(:detect) { { type: :digit, params: {} } }
-      let(:event_type) { 'digit' }
-      let(:event_value) { '1' }
-
-      it "unblocks on a digit" do
-        subject.notification_handler(mock_detect_event)
-        expect(subject.state).to eq '1'
-        expect(subject.completed).to eq true
+        })
       end
     end
 
+    describe "#notification_handler" do
+      let(:mock_detect_event) do
+        Signalwire::Relay::Event.new({
+          params: { params: { params: {
+            detect: {
+              type: event_type,
+              params: {
+                event: event_value
+              }
+            }
+          }}}
+        })
+      end
 
-    describe "machine" do
+      describe "digits" do
+        let(:detect) { { type: :digit, params: {} } }
+        let(:event_type) { 'digit' }
+        let(:event_value) { '1' }
+
+        it "unblocks on a digit" do
+          subject.notification_handler(mock_detect_event)
+          expect(subject.state).to eq '1'
+          expect(subject.completed).to eq true
+        end
+      end
+
+
+      describe "machine" do
+        let(:detect) { { type: :machine, params: {} } }
+        let(:event_type) { 'machine' }
+        let(:event_value) { 'MACHINE' }
+
+        it "unblocks on a READY" do
+          subject.notification_handler(mock_detect_event)
+          expect(subject.state).to eq 'MACHINE'
+        end
+      end
+    end
+  end
+
+  context "Finishing calls" do
+    describe "On complete" do
       let(:detect) { { type: :machine, params: {} } }
       let(:event_type) { 'machine' }
-      let(:event_value) { 'MACHINE' }
+      let(:event_value) { 'finished' }
 
-      it "unblocks on a READY" do
+      let(:mock_detect_event) do
+        Signalwire::Relay::Event.new({
+          params: { params: { params: {
+            detect: {
+              type: event_type,
+              params: {
+                event: event_value
+              }
+            }
+          }}}
+        })
+      end
+
+      it "returns successful as true" do
+        allow_any_instance_of(Signalwire::Relay::Calling::Detect).to receive(:has_blocker?).and_return(true)
+        allow_any_instance_of(Signalwire::Relay::Calling::Detect).to receive(:unblock)
+
         subject.notification_handler(mock_detect_event)
-        expect(subject.state).to eq 'MACHINE'
+
+        expect(subject.successful).to be true
+      end
+
+      it "returns type as machine" do
+        allow_any_instance_of(Signalwire::Relay::Calling::Detect).to receive(:has_blocker?).and_return(true)
+        allow_any_instance_of(Signalwire::Relay::Calling::Detect).to receive(:unblock)
+
+        subject.notification_handler(mock_detect_event)
+
+        expect(subject.type).to eq 'machine'
+      end
+
+      it "returns result as 'finished'" do
+        allow_any_instance_of(Signalwire::Relay::Calling::Detect).to receive(:has_blocker?).and_return(true)
+        allow_any_instance_of(Signalwire::Relay::Calling::Detect).to receive(:unblock)
+
+        subject.notification_handler(mock_detect_event)
+
+        expect(subject.result).to eq 'finished'
       end
     end
   end


### PR DESCRIPTION
Ensures we return successful as true when the call has completed with a `FINISH` event during detecting a beep. 