### PR TITLE
Fix record after execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `record` correctly set up for terminators now.
 
 ## [2.3.2] - 2020-01-29
 ### Fixed

--- a/examples/relay/outbound_record.rb
+++ b/examples/relay/outbound_record.rb
@@ -16,7 +16,7 @@ class OutboundConsumer < Signalwire::Relay::Consumer
     call.dial
     call.play_tts text: 'please leave your message after the beep. Press pound when done.'
     result = call.record(beep: true, terminators: "#")
-    sleep 2
+    sleep 1 # wait for recording to be uploaded
     call.play_tts text: 'you said:'
     call.play_audio result.url
     call.hangup

--- a/examples/relay/outbound_record.rb
+++ b/examples/relay/outbound_record.rb
@@ -16,6 +16,7 @@ class OutboundConsumer < Signalwire::Relay::Consumer
     call.dial
     call.play_tts text: 'please leave your message after the beep. Press pound when done.'
     result = call.record(beep: true, terminators: "#")
+    sleep 2
     call.play_tts text: 'you said:'
     call.play_audio result.url
     call.hangup

--- a/lib/signalwire/relay/calling/component/record.rb
+++ b/lib/signalwire/relay/calling/component/record.rb
@@ -51,7 +51,7 @@ module Signalwire::Relay::Calling
     end
 
     def after_execute(execute_event)
-      @url = execute_event.call_params[:url]
+      @url = execute_event.dig(:params, :params, :params, :url)
     end
   end
 end


### PR DESCRIPTION
This addresses an issue where `record` would not function properly with a terminator.