### PR TITLE
Add Ruby SDK user agent param to blade.connect

### DIFF
--- a/lib/signalwire/blade/message/connect.rb
+++ b/lib/signalwire/blade/message/connect.rb
@@ -10,7 +10,8 @@ module Signalwire::Blade
             major: 2,
             minor: 1,
             revision: 0
-          }
+          },
+          agent: "Ruby SDK/#{Signalwire::VERSION}"
         }
       }
     end

--- a/spec/signalwire/blade/message/connect_spec.rb
+++ b/spec/signalwire/blade/message/connect_spec.rb
@@ -12,4 +12,10 @@ describe Signalwire::Blade::Connect do
     connect = described_class.new.build_request
     expect(connect.dig(:params, :version)).to eq(major: 2, minor: 1, revision: 0)
   end
+
+  it 'uses the current Agent version number' do
+    connect = described_class.new.build_request
+    expect(connect.dig(:params, :agent)).to eq("Ruby SDK/#{Signalwire::VERSION}")
+  end
+
 end


### PR DESCRIPTION
This adds the Ruby SDK version number to the `blade.connect` message. 