### PR TITLE
Update vcr requirement from ~> 4.0 to ~> 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
   test:

--- a/signalwire.gemspec
+++ b/signalwire.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.67'
   spec.add_development_dependency 'ruby-prof', '~> 0.17'
   spec.add_development_dependency 'simplecov', '~> 0.16'
-  spec.add_development_dependency 'vcr', '~> 4.0'
+  spec.add_development_dependency 'vcr', '~> 5.0'
   spec.add_development_dependency 'webmock', '~> 3.5'
 
   spec.add_dependency 'twilio-ruby', '~> 5.0'


### PR DESCRIPTION
[VCR 6.0 does not suppot Ruby 2.6 ](https://github.com/signalwire/signalwire-ruby/pull/88). This is a step towards updating without dropping Ruby 2.6 tests/support.