### PR TITLE
Remove Ruby 2.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  ## [Unreleased]
 
+## [2.6.0] -
+### Added
+- Remove support for Ruby 2.6
+
 ## [2.5.0] - 2023-10-26
 ### Added
 - Add Middleware `SignalwireWebhookAuthentication`

--- a/lib/signalwire/version.rb
+++ b/lib/signalwire/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Signalwire
-  VERSION = '2.5.0'
+  VERSION = '2.6.0'
 end

--- a/signalwire.gemspec
+++ b/signalwire.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'bundler-audit', '~> 0.6'


### PR DESCRIPTION
Ruby 2.6 was EOL on 2022-04-12

https://www.ruby-lang.org/en/downloads/branches/