### PR TITLE
build: add support for Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [2.6.0] -
 ### Added
 - Remove support for Ruby 2.6
+- Add support for Ruby 3.3
 
 ## [2.5.0] - 2023-10-26
 ### Added


### PR DESCRIPTION
Add 3.3 support to same release as the one dropping 2.6 support.